### PR TITLE
Add chevron to program subpage

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@mdi/js": "^4.4.95",
+    "@mdi/react": "^1.2.1",
     "date-fns": "^2.1.0",
     "lodash": "^4.17.15",
     "react": "^16.8.6",

--- a/src/pages/program/Program.tsx
+++ b/src/pages/program/Program.tsx
@@ -37,7 +37,7 @@ const Program: React.FC<ProgramProps> = () => {
   return (
     <ContentWrapper>
       <PageTitle>Program</PageTitle>
-      <Accordion>
+      <Accordion defaultActiveKey="1">
         <Card>
           <Accordion.Toggle as={Card.Header} eventKey="0">
             <TimeplanEntry>

--- a/src/pages/program/Program.tsx
+++ b/src/pages/program/Program.tsx
@@ -7,6 +7,8 @@ import { PageTitle } from "../../components/PageWrapper/style";
 import colors from "../../constants/colors";
 import comps from "../info/companies";
 import { StandWrapper, StandMap } from "../for-companies/ForCompanies";
+import Icon from "@mdi/react";
+import { mdiChevronDown } from "@mdi/js";
 
 interface ProgramProps {}
 
@@ -43,6 +45,7 @@ const Program: React.FC<ProgramProps> = () => {
             <TimeplanEntry>
               <Time>13:15 - 14:15</Time>
               Lynpresentasjoner i store auditorium
+              <Icon path={mdiChevronDown} size="2em" />
             </TimeplanEntry>
           </Accordion.Toggle>
           <Accordion.Collapse eventKey="0">
@@ -60,6 +63,7 @@ const Program: React.FC<ProgramProps> = () => {
             <TimeplanEntry>
               <Time>14:15 - 18:00</Time>
               Stands i hovedfoajeen
+              <Icon path={mdiChevronDown} size="2em" />
             </TimeplanEntry>
           </Accordion.Toggle>
           <Accordion.Collapse eventKey="1">

--- a/src/pages/program/Program.tsx
+++ b/src/pages/program/Program.tsx
@@ -1,24 +1,13 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import Accordion from "react-bootstrap/Accordion";
-import Card from "react-bootstrap/Card";
 import { ContentWrapper } from "../../components/ContentWrapper";
 import { PageTitle } from "../../components/PageWrapper/style";
-import colors from "../../constants/colors";
 import comps from "../info/companies";
 import { StandWrapper, StandMap } from "../for-companies/ForCompanies";
-import Icon from "@mdi/react";
-import { mdiChevronDown } from "@mdi/js";
+import ProgramCard from "./ProgramCard";
 
 interface ProgramProps {}
-
-const TimeplanEntry = styled.div`
-  padding: 0.5rem;
-`;
-
-const Time = styled.div`
-  color: ${colors.echoLogoDarkBlue};
-`;
 
 const CompanyList = styled.ol`
   display: flex;
@@ -32,6 +21,7 @@ const Company = styled.li`
 `;
 
 const Program: React.FC<ProgramProps> = () => {
+  const [selected, setSelected] = useState<string | undefined>("stands");
   const companies = comps
     .filter(c => c.presentationOrder !== -1)
     .sort((c1, c2) => (c1.presentationOrder > c2.presentationOrder ? 1 : -1));
@@ -39,41 +29,31 @@ const Program: React.FC<ProgramProps> = () => {
   return (
     <ContentWrapper>
       <PageTitle>Program</PageTitle>
-      <Accordion defaultActiveKey="1">
-        <Card>
-          <Accordion.Toggle as={Card.Header} eventKey="0">
-            <TimeplanEntry>
-              <Time>13:15 - 14:15</Time>
-              Lynpresentasjoner i store auditorium
-              <Icon path={mdiChevronDown} size="2em" />
-            </TimeplanEntry>
-          </Accordion.Toggle>
-          <Accordion.Collapse eventKey="0">
-            <Card.Body>
-              <CompanyList>
-                {companies.map(comp => (
-                  <Company>{comp.name}</Company>
-                ))}
-              </CompanyList>
-            </Card.Body>
-          </Accordion.Collapse>
-        </Card>
-        <Card>
-          <Accordion.Toggle as={Card.Header} eventKey="1">
-            <TimeplanEntry>
-              <Time>14:15 - 18:00</Time>
-              Stands i hovedfoajeen
-              <Icon path={mdiChevronDown} size="2em" />
-            </TimeplanEntry>
-          </Accordion.Toggle>
-          <Accordion.Collapse eventKey="1">
-            <Card.Body>
-              <StandWrapper>
-                <StandMap src="/misc/standkart-h19.png" alt="Standkart" />
-              </StandWrapper>
-            </Card.Body>
-          </Accordion.Collapse>
-        </Card>
+      <Accordion defaultActiveKey={selected}>
+        <ProgramCard
+          eventKey="presentation"
+          title="13:15 - 14:15"
+          description="Lynpresentasjoner i store auditorium"
+          selected={selected}
+          setSelected={setSelected}
+        >
+          <CompanyList>
+            {companies.map(comp => (
+              <Company>{comp.name}</Company>
+            ))}
+          </CompanyList>
+        </ProgramCard>
+        <ProgramCard
+          eventKey="stands"
+          title="14:15 - 18:00"
+          description="Stands i hovedfoajeen"
+          selected={selected}
+          setSelected={setSelected}
+        >
+          <StandWrapper>
+            <StandMap src="/misc/standkart-h19.png" alt="Standkart" />
+          </StandWrapper>
+        </ProgramCard>
       </Accordion>
     </ContentWrapper>
   );

--- a/src/pages/program/Program.tsx
+++ b/src/pages/program/Program.tsx
@@ -21,7 +21,7 @@ const Company = styled.li`
 `;
 
 const Program: React.FC<ProgramProps> = () => {
-  const [selected, setSelected] = useState<string | undefined>("stands");
+  const [selected, setSelected] = useState<string | undefined>("presentation");
   const companies = comps
     .filter(c => c.presentationOrder !== -1)
     .sort((c1, c2) => (c1.presentationOrder > c2.presentationOrder ? 1 : -1));

--- a/src/pages/program/ProgramCard.tsx
+++ b/src/pages/program/ProgramCard.tsx
@@ -1,0 +1,61 @@
+import React, { ReactNode } from "react";
+import styled from "styled-components";
+import Accordion from "react-bootstrap/Accordion";
+import Card from "react-bootstrap/Card";
+import Icon from "@mdi/react";
+import { mdiChevronDown, mdiChevronRight } from "@mdi/js";
+import colors from "../../constants/colors";
+
+const TimeplanEntry = styled.div`
+  padding: 0.5rem;
+`;
+
+const Time = styled.div`
+  color: ${colors.echoLogoDarkBlue};
+`;
+
+interface ProgramCardInterface {
+  eventKey: string;
+  title: string;
+  description: string;
+  selected: string | undefined;
+  setSelected(name: string | undefined): void;
+  children: ReactNode;
+}
+
+const ProgramCard: React.FC<ProgramCardInterface> = ({
+  eventKey,
+  title,
+  description,
+  selected,
+  setSelected,
+  children
+}) => {
+  return (
+    <Card>
+      <Accordion.Toggle
+        as={Card.Header}
+        eventKey={eventKey}
+        onClick={() => {
+          selected === eventKey
+            ? setSelected(undefined)
+            : setSelected(eventKey);
+        }}
+      >
+        <TimeplanEntry>
+          <Time>{title}</Time>
+          {description}
+          <Icon
+            path={selected === eventKey ? mdiChevronDown : mdiChevronRight}
+            size="2em"
+          />
+        </TimeplanEntry>
+      </Accordion.Toggle>
+      <Accordion.Collapse eventKey={eventKey}>
+        <Card.Body>{children}</Card.Body>
+      </Accordion.Collapse>
+    </Card>
+  );
+};
+
+export default ProgramCard;

--- a/src/pages/program/ProgramCard.tsx
+++ b/src/pages/program/ProgramCard.tsx
@@ -8,10 +8,18 @@ import colors from "../../constants/colors";
 
 const TimeplanEntry = styled.div`
   padding: 0.5rem;
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: space-between;
 `;
 
 const Time = styled.div`
   color: ${colors.echoLogoDarkBlue};
+`;
+
+const StyledIcon = styled(Icon)`
+  float: right;
+  align-self: center;
 `;
 
 interface ProgramCardInterface {
@@ -43,11 +51,13 @@ const ProgramCard: React.FC<ProgramCardInterface> = ({
         }}
       >
         <TimeplanEntry>
-          <Time>{title}</Time>
-          {description}
-          <Icon
+          <div>
+            <Time>{title}</Time>
+            <span>{description}</span>
+          </div>
+          <StyledIcon
             path={selected === eventKey ? mdiChevronDown : mdiChevronRight}
-            size="2em"
+            size="2rem"
           />
         </TimeplanEntry>
       </Accordion.Toggle>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1108,6 +1108,16 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@mdi/js@^4.4.95":
+  version "4.4.95"
+  resolved "https://registry.yarnpkg.com/@mdi/js/-/js-4.4.95.tgz#615de98256273b1716dd1e32a6bc4dfdaba3c8a0"
+  integrity sha512-wCrur/ICoHP7/NcNboBCdqR64gQnoUKxSRla4uOsGC61jMUnUeDMNfU7PrA/I0IzvotWc0ws2cCNVL7JsOPh2Q==
+
+"@mdi/react@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@mdi/react/-/react-1.2.1.tgz#24279784e080728e953f3c1a71f49c64031dee47"
+  integrity sha512-1IRIVCT07vlLmaZjVtGfyfwCMivg/tCtPj0+r1BKrkoh9z4xLf+M1TD0LhjJPO+4+O0ibW+xrNRvf+boRRtX9A==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
Nå åpner den default standkartet, som jeg tenker vil bli mest brukt. Usikker på perfekte størrelse og plassering på _chevron_-ene, så bare gi tilbakemelding.
Pluss importerte npm-pakke for ikonene, vet ikke hva dere tenker om det?